### PR TITLE
Bump thor dependency to ~> 0.19.0

### DIFF
--- a/ataru.gemspec
+++ b/ataru.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake", "~> 10.3"
 
-  spec.add_runtime_dependency "minitest", "~> 5.0.0"
-  spec.add_runtime_dependency "kramdown", "~> 1.0.0"
-  spec.add_runtime_dependency "thor", "~> 0.1.0"
+  spec.add_runtime_dependency "minitest", "~> 5.0"
+  spec.add_runtime_dependency "kramdown", "~> 1.3"
+  spec.add_runtime_dependency "thor", "~> 0.19.0"
 end


### PR DESCRIPTION
Thor ~> 0.1.0 is not available from rubygems.

Bump the dependency to the most recent minor.
